### PR TITLE
お気に入りリストの中から公開したいものを選び、SNSでシェアできる

### DIFF
--- a/FavoriteReview/Controller/FavoriteReviewController.php
+++ b/FavoriteReview/Controller/FavoriteReviewController.php
@@ -128,7 +128,7 @@ class FavoriteReviewController extends AbstractController
     /**
      * お気に入り商品を表示する.
      *
-     * @Route("/mypage/favorite", name="mypage_favorite", methods={"GET"})
+     * @Route("/mypage/favorite", name="mypage_favorite", methods={"GET","POST"})
      * @Template("FavoriteReview/Resource/template/Mypage/favorite.twig")
      */
     public function favorite(Request $request, PaginatorInterface $paginator)
@@ -158,12 +158,46 @@ class FavoriteReviewController extends AbstractController
         );
 // dump($pagination);
 // exit;
-            return [
-                'pagination' => $pagination,
-                'Customer' => $Customer
-            ];
 
+        return [
+            'pagination' => $pagination,
+            'Customer' => $Customer,
+        ];
+
+    }
+
+
+    /**
+     * ajax処理で'open'カラムを変えたいidを持ってくる
+     *
+     * @Route("/mypage/open/status", name="change_open_status", methods={"POST"})
+     * @param $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
+    public function changeOpenStatus(Request $request)
+    {
+        if (!$request->isXmlHttpRequest()) {
+            throw new BadRequestHttpException();
         }
+
+        $id = $request->get('id');
+
+
+        $cfp = $this->customerFavoriteProductRepository->find($id);
+        if($cfp->getOpen() == 0){
+            $cfp->setOpen(1);
+        }else{
+            $cfp->setOpen(0);
+        }
+
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($cfp);
+        $em->flush();
+
+        return $this->json([
+            'success' => true
+        ]);
+    }
 
 
 
@@ -449,7 +483,7 @@ class FavoriteReviewController extends AbstractController
         // 送る側のユーザー情報を取得
         $user = $this->getUser();
         $user_id = $user->getId();
-        
+
             if($request->getMethod() == "POST"){
 
                 $count = $this->giftRepository->getCount()->getQuery()->getSingleScalarResult() + 1;

--- a/FavoriteReview/Entity/CustomerFavoriteProductTrait.php
+++ b/FavoriteReview/Entity/CustomerFavoriteProductTrait.php
@@ -26,6 +26,13 @@ trait CustomerFavoriteProductTrait
     private $priority;
 
     /**
+     * @var boolean
+     *
+     * @ORM\Column(name="open", type="boolean", options={"default":false})
+     */
+    private $open;
+
+    /**
      * Set comment.
      *
      *
@@ -72,6 +79,30 @@ trait CustomerFavoriteProductTrait
     public function getPriority()
     {
         return $this->priority;
+    }
+
+    /**
+     * Set open.
+     *
+     * @param boolean $open
+     *
+     * @return Customer
+     */
+    public function setOpen($open)
+    {
+        $this->open = $open;
+
+        return $this;
+    }
+
+    /**
+     * Get open.
+     *
+     * @return boolean
+     */
+    public function getOpen()
+    {
+        return $this->open;
     }
 
 }

--- a/FavoriteReview/Resource/template/Mypage/favorite.twig
+++ b/FavoriteReview/Resource/template/Mypage/favorite.twig
@@ -14,10 +14,16 @@ file that was distributed with this source code.
 
 {% set body_class = 'mypage' %}
 
-{% block main %}
-
 {% block stylesheet %}
+
 <style>
+.fa-eye{
+    color: #e6e6fa;
+    cursor: pointer;
+}
+.opened{
+    color: #eb6100;
+}
 .star-display{
   display: flex;
 }
@@ -33,8 +39,11 @@ file that was distributed with this source code.
   color: #ccc;
   font-size: 20px;
 }
+.edit-comment{
+    margin: 4px 0;
+}
 .edit-comment a{
-  font-size: 14px;
+  font-size: 16px;
   padding: 2px;
   border: solid 1px #333;
   border-radius:2px;
@@ -45,23 +54,40 @@ a.btn--sns {
   color: #fff;
   background-color: #eb6100;
 }
-/* .btn--comment,
-a.btn--comment {
-  color: #fff;
-  background-color: #505050;
-} */
 .btn--sns:hover,
 a.btn--sns:hover {
   color: #fff;
   background: #f56500;
 }
-/* .btn--comment:hover,
-a.btn--comment:hover {
-  color: #fff;
-  background: #686868;
-} */
 </style>
 {% endblock %}
+
+
+{% block javascript %}
+<script>
+$(function(){
+    let open = $('.open-toggle');
+    let openId;
+    open.on('click',function(){
+        let $this = $(this); //this=イベントの発火した要素＝iタグを代入
+        openId = $this.data('id'); //iタグに仕込んだdata-idの値を得る
+        $.ajax({
+            method: "POST",
+            url: "/mypage/open/status",
+            data: {'id' : openId},
+            })
+            .done(function(data){
+            $this.toggleClass('opened');
+            console.log('success!');
+            }).fail(function(){
+            console.log('fail!!')
+        });
+    });
+});
+</script>
+{% endblock %}
+
+{% block main %}
 
     <div class="ec-layoutRole__main">
         <div class="ec-mypageRole">
@@ -70,7 +96,6 @@ a.btn--comment:hover {
             </div>
             {% include 'Mypage/navi.twig' %}
         </div>
-{# {{ dump() }} #}
         <div class="ec-mypageRole">
             <div class="ec-favoriteRole">
                 {% if pagination.totalItemCount > 0 %}
@@ -95,8 +120,8 @@ a.btn--comment:hover {
                                         </p>
                                     </a>
                                     <p class="ec-favoriteRole__itemTitle">{{ Product.name }}</p>
-                                    <form>
-                                    <input type="hidden"
+
+
                                     <p class="ec-favoriteRole__itemPrice">
                                         {% if Product.price02_inc_tax_min == Product.price02_inc_tax_max %}
                                             {{ Product.price02_inc_tax_min|price }}
@@ -104,7 +129,6 @@ a.btn--comment:hover {
                                             {{ Product.price02_inc_tax_min|price }}～{{ Product.price02_inc_tax_max|price }}
                                         {% endif %}
                                     </p>
-                                    {# {{ dump() }} #}
                                     <p>{{ FavoriteProduct.comment }}</p>
                                     <div class="star-display">
                                         {% for i in range(1,4) %}
@@ -114,8 +138,17 @@ a.btn--comment:hover {
                                         {% endfor %}
                                     </div>
 
+
                                     <div class="edit-comment">
                                     <a href="{{ url('mypage_favorite_update', { id : FavoriteProduct.id }) }}">コメントを編集</a>
+                                    {# <input type="submit" action="{{ url('mypage_favorite_open', { id : FavoriteProduct.id }) }}" method="POST"> #}
+                                    </div>
+                                    <div class="open-status-wrapper">
+                                        {% if FavoriteProduct.open %}
+                                        <i class="fas fa-eye open-toggle opened" data-id={{FavoriteProduct.id}}></i>
+                                        {% else %}
+                                        <i class="fas fa-eye open-toggle" data-id={{FavoriteProduct.id}}></i>
+                                        {% endif %}
                                     </div>
 
                                 </li>
@@ -132,6 +165,7 @@ a.btn--comment:hover {
                 <a href="{{ url('favorite_share', { user_id : Customer.id }) }}" class="btn btn--sns">SNSでシェアする</a>
                 </div>
             </div>
+
         </div>
     </div>
 {% endblock %}

--- a/FavoriteReview/Resource/template/Mypage/favorite_share.twig
+++ b/FavoriteReview/Resource/template/Mypage/favorite_share.twig
@@ -8,11 +8,11 @@
 
 <style>
 .form-wrapper{
-    border-bottom: 1px solid #32a1ce;
-    margin:10px 2% 20px 50%;
+  border-bottom: 1px solid #32a1ce;
+  margin:10px 2% 20px 50%;
 }
 .favorite-share-form{
-    margin:10px 2% 10px 10%;
+  margin:10px 2% 10px 10%;
 }
 .star-display{
   display: flex;
@@ -30,11 +30,11 @@
   font-size: 20px;
 }
 .fab{
-    margin: 0 10px 20px 10px;
+  margin: 0 10px 20px 10px;
 }
 .sns-share{
-    border-top: 1px solid #32a1ce;
-    margin:10px 50% 10px 0;
+  border-top: 1px solid #32a1ce;
+  margin:10px 50% 10px 0;
 }
 </style>
 
@@ -70,6 +70,7 @@
                         <ul class="ec-favoriteRole__itemList">
                             {% for FavoriteProduct in pagination %}
                                 {% set Product = FavoriteProduct.Product %}
+                                {% if FavoriteProduct.open %}
                                 <li class="ec-favoriteRole__item">
                                     <a class="ec-favoriteRole__itemThumb" href="{{ url('product_detail', {'id': Product.id}) }}">
                                         <p class="ec-favoriteRole__item-image">
@@ -98,6 +99,7 @@
                                         {% endif %}
                                     </div>
                                 </li>
+                                {% endif %}
                             {% endfor %}
                         </ul>
                     </div>


### PR DESCRIPTION
favorite.twigにて、各商品の下に目玉のアイコンをつける。
目玉のアイコンをクリックするとajax処理でcustomerFavoriteProductテーブルのopenカラムの値が切り替わり、公開/非公開の切り替わりに対応している。
SNSシェアページ（favorite_share.twig)では、openカラムがtrueの商品のみ並べる。
