### PR TITLE
db_giftへの登録をauto incrementを使った形に変更

### DIFF
--- a/FavoriteReview/Controller/FavoriteReviewController.php
+++ b/FavoriteReview/Controller/FavoriteReviewController.php
@@ -162,7 +162,8 @@ class FavoriteReviewController extends AbstractController
         $pagination = $paginator->paginate(
             $qb,
             $request->get('pageno', 1),
-            $this->eccubeConfig['eccube_search_pmax'],
+            // $this->eccubeConfig['eccube_search_pmax'],
+            10,
             ['wrap-queries' => true]
         );
 // dump($pagination);
@@ -374,7 +375,17 @@ class FavoriteReviewController extends AbstractController
             $qb,
             $request->get('pageno', 1),
             $this->eccubeConfig['eccube_search_pmax'],
+            // 12,
             ['wrap-queries' => true]
+        );
+        // $pagination->appends(Input::all());
+
+        $qb2 = $this->giftRepository->getQueryBuilderByTakeUserId($user_id);
+
+        $pagination2 = $paginator->paginate(
+            $qb2,
+            $request->get('pageno', 1),
+            10,
         );
 
         $share = $Customer->getShare();
@@ -439,13 +450,15 @@ class FavoriteReviewController extends AbstractController
 
         return [
             'pagination' => $pagination,
+            'pagination2' => $pagination2,
             'twitter_share_url' => $twitter_share_url,
             'facebook_share_url' => $facebook_share_url,
             'Customer' => $Customer,
             'user_id' => $user_id,
             'form' => $form->createView(),
             'auth' => $auth,
-            'canGift' => $canGift
+            'canGift' => $canGift,
+            'qb2' => $qb2
         ];
 
     }
@@ -496,12 +509,10 @@ class FavoriteReviewController extends AbstractController
 
             if($request->getMethod() == "POST"){
 
-                $count = $this->giftRepository->getCount()->getQuery()->getSingleScalarResult() + 1;
-
                 $form->handleRequest($request);
                 $gift = new \Plugin\FavoriteReview\Entity\Gift();
-                $gift->setId($count)
-                ->setGiveUserId($user_id)
+
+                $gift->setGiveUserId($user_id)
                 ->setTakeUserId($taker_id)
                 ->setFavoriteId($id)
                 ->setComment($form->get('comment')->getData())
@@ -516,19 +527,9 @@ class FavoriteReviewController extends AbstractController
 
                 }
 
-                //もしgiftに値があるならデータを取ってくる
-                // $giftId = $count - 1;
-                // $abc = $this->giftRepository->find(13);
-                // dump($abc);
-                // exit;
-                // if($this->giftRepository->find(13)){
-                //     $gifterInfo = $this->giftRepository->getQueryBuilderById($giftId);
-                // }
-
                 return $this->render(
                     'FavoriteReview/Resource/template/Mypage/gift_purchase_confirm.twig',
                     [
-                        'gift_id' => $count,
                         'gift' => $gift,
                         'pagination' => $pagination,
                         'form' => $form->createView(),

--- a/FavoriteReview/Entity/Gift.php
+++ b/FavoriteReview/Entity/Gift.php
@@ -40,27 +40,21 @@ if (!class_exists('\Plugin\FavoriteReview\Entity\Gift')) {
         /**
          * @var integer
          *
-         * @ORM\Column(name="give_user_id", type="integer", options={"unsigned":true})
-         * @ORM\Id
-         * @ORM\GeneratedValue(strategy="NONE")
+         * @ORM\Column(name="give_user_id", type="integer")
          */
         private $give_user_id;
 
         /**
          * @var integer
          *
-         * @ORM\Column(name="take_user_id", type="integer", options={"unsigned":true})
-         * @ORM\Id
-         * @ORM\GeneratedValue(strategy="NONE")
+         * @ORM\Column(name="take_user_id", type="integer")
          */
         private $take_user_id;
 
         /**
          * @var integer
          *
-         * @ORM\Column(name="favorite_id", type="integer", options={"unsigned":true})
-         * @ORM\Id
-         * @ORM\GeneratedValue(strategy="NONE")
+         * @ORM\Column(name="favorite_id", type="integer")
          */
         private $favorite_id;
 

--- a/FavoriteReview/Repository/GiftRepository.php
+++ b/FavoriteReview/Repository/GiftRepository.php
@@ -48,14 +48,26 @@ class GiftRepository extends AbstractRepository
     }
 
     /**
+     * @param $take_user_id
+     *
      * @return QueryBuilder
      */
-    public function getCount()
+    public function getQueryBuilderByTakeUserId($user_id)
     {
         $qb = $this->createQueryBuilder('g')
-            ->select('COUNT(g.id)');
+            ->select('g.comment, g.name AS sender_name, cfp.priority, p.name')
+            ->leftJoin('Eccube\Entity\CustomerFavoriteProduct', 'cfp', 'WITH', 'g.favorite_id = cfp.id')
+            ->innerJoin('cfp.Product', 'p')
+            // ->leftJoin('Eccube\Entity\ProductImage', 'pi', 'WITH', 'p.id = pi.product_id')
+
+            ->where('g.take_user_id = :user_id')
+            ->setParameter('user_id', $user_id)
+            ->getQuery()
+            ->getResult();
 
         return $qb;
     }
-}
 
+
+
+}


### PR DESCRIPTION
giftエンティティにて@ORM\Idで定義していたカラムが４つあったので、主キー以外をinteger型にしたところ、無事autoincrementを利用した（setIdを用いない）登録をすることができた。