### PR TITLE
お気に入りページのUIを改良。タブ機能を追加。

### DIFF
--- a/FavoriteReview/Resource/template/Mypage/favorite.twig
+++ b/FavoriteReview/Resource/template/Mypage/favorite.twig
@@ -59,6 +59,51 @@ a.btn--sns:hover {
   color: #fff;
   background: #f56500;
 }
+.favoriteRole__item-wrapper{
+  display:inline-block;
+  padding: 7px;
+  border:thick double #32a1ce;
+  border-radius:15px;
+  /* display:hidden; */
+}
+.privatePublicToggleTab li.active a{
+  color:#c61e79;
+}
+.privatePublicToggleTab li a{
+  text-decoration: none;
+  color: #666;
+  font-weight: 700;
+  display: block;
+  cursor: pointer;
+}
+.privatePublicToggleTab li a:hover{
+  opacity:0.6;
+}
+.privatePublicToggleTab {
+    max-width: 500px;
+    margin: 0 auto;
+    padding-bottom: 8px;
+}
+.privatePublicToggleTab ul {
+    clear: both;
+    overflow: hidden;
+}
+.privatePublicToggleTab li.active {
+    border-bottom-color: #c61e79;
+}
+.privatePublicToggleTab li {
+    background: #fff;
+    width: 33%;
+    float: left;
+    line-height: 30px;
+    text-align: center;
+    color: #c61e79;
+    height: 30px;
+    list-style: none;
+    border-bottom: solid 3px #f6f6f6;
+    -webkit-backface-visibility: hidden;
+    transition: opacity .1s;
+}
 </style>
 {% endblock %}
 
@@ -98,6 +143,12 @@ $(function(){
         </div>
         <div class="ec-mypageRole">
             <div class="ec-favoriteRole">
+            <div class="privatePublicToggleTab">
+                <ul>
+                    <li class="left-filter active"><a>private</a></li>
+                    <li class="right-filter"><a href="{{ url('favorite_share', { user_id : Customer.id }) }}">public</a></li>
+                </ul>
+            </div>
                 {% if pagination.totalItemCount > 0 %}
                     <div class="ec-favoriteRole__header">
                         <p>{{ 'front.mypage.favorite_count'|trans({'%count%':pagination.totalItemCount}) }}</p>
@@ -107,6 +158,7 @@ $(function(){
                             {% for FavoriteProduct in pagination %}
                                 {% set Product = FavoriteProduct.Product %}
                                 <li class="ec-favoriteRole__item">
+                                <div class="favoriteRole__item-wrapper">
                                     <a class="ec-closeBtn--circle"
                                        href="{{ url('mypage_favorite_delete', { id : Product.id }) }}" {{ csrf_token_for_anchor() }}
                                        data-method="delete">
@@ -151,6 +203,7 @@ $(function(){
                                         {% endif %}
                                     </div>
 
+                                </div>
                                 </li>
                             {% endfor %}
                         </ul>

--- a/FavoriteReview/Resource/template/Mypage/favorite_share.twig
+++ b/FavoriteReview/Resource/template/Mypage/favorite_share.twig
@@ -4,7 +4,7 @@
 
 {% set body_class = 'mypage' %}
 
-{% block main %}
+{% block stylesheet %}
 
 <style>
 .form-wrapper{
@@ -94,17 +94,70 @@
 /* .take_gift_wrapper{
   height: 200px;
 } */
+.privatePublicToggleTab li.active a{
+  color:#c61e79;
+}
+.privatePublicToggleTab li a{
+  text-decoration: none;
+  color: #666;
+  font-weight: 700;
+  display: block;
+  cursor: pointer;
+}
+.privatePublicToggleTab li a:hover{
+  opacity:0.6;
+}
+.privatePublicToggleTab {
+    max-width: 500px;
+    margin: 0 auto;
+    padding-bottom: 8px;
+}
+.privatePublicToggleTab ul {
+    clear: both;
+    overflow: hidden;
+}
+.privatePublicToggleTab li.active {
+    border-bottom-color: #c61e79;
+}
+.privatePublicToggleTab li {
+    background: #fff;
+    width: 33%;
+    float: left;
+    line-height: 30px;
+    text-align: center;
+    color: #c61e79;
+    height: 30px;
+    list-style: none;
+    border-bottom: solid 3px #f6f6f6;
+    -webkit-backface-visibility: hidden;
+    transition: opacity .1s;
+}
 </style>
+
+{% endblock %}
 
 {# <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet"> #}
 
+{% block main %}
+
+{% include "Block/header.twig" %}
+{% include "Block/logo.twig" %}
+{% include "Block/category_nav_pc.twig" %}
 
     <div class="ec-layoutRole__main">
         <div class="ec-mypageRole">
             <div class="ec-pageHeader">
                 <h1>{{ Customer.name01 }}{{ Customer.name02 }}さんのお気に入り一覧</h1>
             </div>
+            {% if auth %}
             {% include 'Mypage/navi.twig' %}
+            {% endif %}
+        </div>
+        <div class="privatePublicToggleTab">
+            <ul>
+                <li class="left-filter"><a href="{{ url('mypage_favorite') }}">private</a></li>
+                <li class="right-filter active"><a href="{{ url('favorite_share', { user_id : Customer.id }) }}">public</a></li>
+            </ul>
         </div>
         {% if auth  %}
         <div class="form-wrapper">
@@ -162,36 +215,38 @@
                         </ul>
                     </div>
                     <div class="ec-pagerRole">
-                        {% include "pager.twig" with {'pages': pagination.paginationData} %}
+                        {% include "gift_pager.twig" with {'pages': pagination.paginationData} %}
                     </div>
                 {% else %}
                     <div class="ec-favoriteRole__header">{{ 'front.mypage.favorite_not_found'|trans }}</div>
                 {% endif %}
 
 
-                <div class="gift_take_history">
-                {% if pagination2.totalItemCount > 0 %}
-                <h2> 受け取ったギフト</h2>
-                    {% for items in pagination2 %}
-                    <div class="take_gift_wrapper">
-                        <div class="take_history_name">
-                        <p>{{ items.sender_name }}</p>
-                        </div>
-                        <div class="baloon">
-                            <div class="balloon2-left">
-                            <p>{{ items.comment }}</p>
+                {% if auth %}
+                    <div class="gift_take_history">
+                    {% if pagination2.totalItemCount > 0 %}
+                    <h2> 受け取ったギフト</h2>
+                        {% for items in pagination2 %}
+                        <div class="take_gift_wrapper">
+                            <div class="take_history_name">
+                            <p>{{ items.sender_name }}</p>
+                            </div>
+                            <div class="baloon">
+                                <div class="balloon2-left">
+                                <p>{{ items.comment }}</p>
+                                </div>
+                            </div>
+                            <div class="take_history_item_name">
+                            {{ items.name }}
                             </div>
                         </div>
-                        <div class="take_history_item_name">
-                        {{ items.name }}
-                        </div>
-                    </div>
-                    {% endfor %}
+                        {% endfor %}
 
-                    {# <div class="ec-pagerRole">
-                        {% include "pager.twig" with {'pages': pagination2.paginationData} %}
-                    </div> #}
+                        {# <div class="ec-pagerRole">
+                            {% include "pager.twig" with {'pages': pagination2.paginationData} %}
+                        </div> #}
 
+                    {% endif %}
                 {% endif %}
                 </div>
 


### PR DESCRIPTION
やったこと
・商品と背景の境が分かりにくかったので、商品に囲み線をつけた
・お気に入りリストと公開リストの切り替えを分かりやすくするため、タブを実装した

問題点
・タブの切り替えで別のページにリンクを飛ばしているので、ページ遷移の前後でページをスクロールしていた分だけずれる。
・公開リストページでいちいち {% include "Block/header.twig" %}などとしてヘッダーを表示させページの高さを合わせた。お気に入りページはincludeせずに使えているが、どのような仕組みなのか。公開ページで使えるならコードがシンプルになるので真似したい。
