### PR TITLE
シェアページのURLを複雑化する。

### DIFF
--- a/FavoriteReview/Entity/CustomerTrait.php
+++ b/FavoriteReview/Entity/CustomerTrait.php
@@ -26,6 +26,14 @@ trait CustomerTrait
     private $gift;
 
     /**
+     * @var string|null
+     *
+     * @ORM\Column(name="url", type="string", length=255, nullable=true)
+     */
+    private $url;
+
+
+    /**
      * Set share.
      *
      * @param boolean $share
@@ -73,4 +81,27 @@ trait CustomerTrait
         return $this->gift;
     }
 
+    /**
+     * Set url.
+     *
+     * @param string $url
+     *
+     * @return Customer
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * Get url.
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
 }

--- a/FavoriteReview/Repository/Extension/CustomerRepositoryExtension.php
+++ b/FavoriteReview/Repository/Extension/CustomerRepositoryExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\FavoriteReview\Repository\Extension;
+
+use Eccube\Repository\CustomerRepository;
+
+class CustomerRepositoryExtension extends CustomerRepository
+{
+
+    /**
+     *
+     * @param $url
+     *
+     * @return QueryBuilder
+     */
+    public function getUserFromUrl($url)
+    {
+        $qb = $this->createQueryBuilder('c')
+        ->select('c.id')
+        ->where('c.url = :url')
+        ->setParameter('url', $url);
+
+        $id = $qb
+            ->getQuery()
+            ->getSingleScalarResult();
+
+
+        return $id;
+    }
+
+}

--- a/FavoriteReview/Resource/template/Mypage/favorite_share.twig
+++ b/FavoriteReview/Resource/template/Mypage/favorite_share.twig
@@ -153,19 +153,14 @@
             {% include 'Mypage/navi.twig' %}
             {% endif %}
         </div>
-        <div class="privatePublicToggleTab">
-            <ul>
-                <li class="left-filter"><a href="{{ url('mypage_favorite') }}">private</a></li>
-                <li class="right-filter active"><a href="{{ url('favorite_share', { user_id : Customer.id }) }}">public</a></li>
-            </ul>
-        </div>
+
         {% if auth  %}
         <div class="form-wrapper">
         <h4>ページを公開する</h4>
             <div class="favorite-share-form">
                 {{ form_start(form) }}
                 {{ form_widget(form) }}
-                <input type="submit" action="{{ url('favorite_share', { user_id : Customer.id }) }}" method="POST">
+                <input type="submit" action="{{ url('favorite_share', { user_url : user_url }) }}" method="POST">
 
                 {{ form_end(form) }}
             </div>


### PR DESCRIPTION
初めて非公開→公開にする際に１６進数３２桁の文字列をCustomer テーブルのurlカラムに登録する
シェアページはfavorite_share/{user_url}というURLでアクセスできるようになる
１６進数３２桁の文字列は高速で暗号性のあるものを用いた（参考：https://pentan.info/php/sample/uniq_id.html）
