### PR TITLE
publicタブ→鍵アイコンの２段階でリスト公開ができる。非公開もワンタップ。

### DIFF
--- a/FavoriteReview/Controller/FavoriteReviewController.php
+++ b/FavoriteReview/Controller/FavoriteReviewController.php
@@ -168,11 +168,13 @@ class FavoriteReviewController extends AbstractController
         );
 
         $openCount = $this->customerFavoriteProductRepository->getOpenCount($Customer);
+        $share = $this->customerRepository->find($Customer)->getShare();
 
         return [
             'pagination' => $pagination,
             'Customer' => $Customer,
             'openCount' => $openCount,
+            'share' => $share,
         ];
 
     }
@@ -210,6 +212,37 @@ class FavoriteReviewController extends AbstractController
         ]);
     }
 
+    /**
+     * ajax処理で'open'カラムを変えたいidを持ってくる
+     *
+     * @Route("/mypage/lock/status", name="change_lock_status", methods={"POST"})
+     * @param $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
+    public function changeLockStatus(Request $request)
+    {
+        if (!$request->isXmlHttpRequest()) {
+            throw new BadRequestHttpException();
+        }
+
+        $no = $request->get('no');
+        $Customer = $this->getUser();
+
+        $c = $this->customerRepository->find($Customer);
+        if($no == 0){
+            $c->setShare(1);
+        }else{
+            $c->setShare(0);
+        }
+
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($c);
+        $em->flush();
+
+        return $this->json([
+            'success' => true
+        ]);
+    }
 
 
     /**

--- a/FavoriteReview/Resource/template/Mypage/favorite.twig
+++ b/FavoriteReview/Resource/template/Mypage/favorite.twig
@@ -123,6 +123,12 @@ a.btn--sns:hover {
 /* .ec-favoriteRole__header{
   display:block;
 } */
+.lock-item{
+    display:inline-block;
+}
+.lock-item.active2{
+    display:none;
+}
 </style>
 {% endblock %}
 
@@ -151,21 +157,37 @@ $(function(){
 
 $(function() {
   $('.tab-item').click(function() {
-
     //現在activeが付いているクラスからactiveを外す
     $('.active').removeClass('active');
-
     //クリックされたタブメニューにactiveクラスを付与。
     $(this).addClass('active');
-
     //一旦showクラスを外す
     $('.show').removeClass('show');
-
     //クリックしたタブのインデックス番号取得
     const index = $(this).index();
-
     //タブのインデックス番号と同じコンテンツにshowクラスをつけて表示する
     $('.tab-content').eq(index).addClass('show');
+  });
+});
+
+$(function() {
+  $('.lock-item').click(function() {
+    let $this = $(this); //this=イベントの発火した要素＝iタグを代入
+    no = $this.data('no'); //iタグに仕込んだdata-idの値を得る
+    $.ajax({
+            method: "POST",
+            url: "/mypage/lock/status",
+            data: {'no' : no},
+            })
+            .done(function(data){
+            //現在activeが付いているクラスからactiveを外す
+            $('.active2').removeClass('active2');
+            //クリックされたタブメニューにactiveクラスを付与。
+            $this.addClass('active2');
+            console.log('success!');
+            }).fail(function(){
+            console.log('fail!!')
+        });
   });
 });
 </script>
@@ -259,7 +281,27 @@ $(function() {
                 <div class="ec-favoriteRole">
                     {% if pagination.totalItemCount > 0 %}
                         <div class="ec-favoriteRole__header">
+                            <div class="lock">
+                            {% if share %}
+                            <div class="lock-item">
                             <p>{{ openCount }}件を公開しています</p>
+                                <i class="fas fa-lock-open" data-no=1></i>
+                            </div>
+                            <div class="lock-item active2">
+                            <p>{{ openCount }}件を公開できます</p>
+                                <i class="fas fa-lock" data-no=0></i>
+                            </div>
+                            {% else %}
+                            <div class="lock-item active2">
+                            <p>{{ openCount }}件を公開しています</p>
+                                <i class="fas fa-lock-open" data-no=1></i>
+                            </div>
+                            <div class="lock-item">
+                            <p>{{ openCount }}件を公開できます</p>
+                                <i class="fas fa-lock" data-no=0></i>
+                            </div>
+                            {% endif %}
+                            </div>
                         </div>
                         <div class="ec-favoriteRole__detail">
                             <ul class="ec-favoriteRole__itemList">


### PR DESCRIPTION
・実装した理由
publicタブで公開できる商品の一覧を見れるが、実際に公開するまでにはもう１段階挟んだ方が、プライバシーを守れると思い実装。
今までは「①シェアページで②フォーム入力送信から」切り替えていたが、
これからは「①お気に入りページで②アイコンのクリック」で切り替わることで、ユーザーの使い勝手が上がる。
・仕組み
shareカラムの値によって南京錠の開閉イラストを分岐。鍵イラストを押したらajax処理でshareカラムの値と鍵の開閉が切り替わる。
